### PR TITLE
fix: Fixed the close event and optimised heap usage

### DIFF
--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/LinkedInventoryBuilder.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/LinkedInventoryBuilder.kt
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit
 import org.bukkit.block.Container
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
+import org.bukkit.event.HandlerList
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.*
 import org.bukkit.event.player.PlayerSwapHandItemsEvent
@@ -78,8 +79,8 @@ data class LinkedInventoryBuilder(
     @EventHandler
     private fun InventoryClickEvent.listener() {
         if (title.compareTo(this.view.title())) {
-            if (inventoryIds.contains(id) && this.currentItem != null && this.view.player == player) {
-                if (this.inventory == inventory) {
+            if (inventoryIds.contains(id) && this.currentItem != null && view.player == this@LinkedInventoryBuilder.player) {
+                if (inventory == this@LinkedInventoryBuilder.inventory) {
                     for (slot in slots.entries) {
                         if (slot.key == this.rawSlot){
                             this.isCancelled = true
@@ -93,6 +94,7 @@ data class LinkedInventoryBuilder(
         }
     }
 
+    @EventHandler
     private fun InventoryMoveItemEvent.listener2() {
         if (inventoryIds.contains(id) && this.source.holder?.inventory?.viewers?.contains(player)!!
             && this.source.holder is Container && (this.source.holder as Container).customName() == title
@@ -102,17 +104,19 @@ data class LinkedInventoryBuilder(
 
     @EventHandler
     private fun InventoryCloseEvent.listener3() {
-        for(closeHandler in closeHandlers) {
-            closeHandler(this)
-        }
-        if (this.view.player == player && inventoryIds.contains(id))
+        if (view.player == this@LinkedInventoryBuilder.player && inventoryIds.contains(id)) {
+            for(closeHandler in closeHandlers) {
+                closeHandler(this)
+            }
             inventoryIds.remove(id)
+            HandlerList.unregisterAll(this@LinkedInventoryBuilder)
+        }
     }
 
     @EventHandler
     private fun PlayerSwapHandItemsEvent.listener4() {
-        if (this.player.inventory == inventory) {
-            this.isCancelled = true
+        if (player.inventory == this@LinkedInventoryBuilder.inventory) {
+            isCancelled = true
         }
     }
 }

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/SimpleInventoryBuilder.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/SimpleInventoryBuilder.kt
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit
 import org.bukkit.block.Container
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
+import org.bukkit.event.HandlerList
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
@@ -65,9 +66,9 @@ class SimpleInventoryBuilder(
 
     @EventHandler
     private fun InventoryClickEvent.listener() {
-        if (title.compareTo(this.view.title())) {
-            if (inventoryIds.contains(id) && this.currentItem != null && this.view.player == player) {
-                if (this.inventory == inventory) {
+        if (title.compareTo(view.title())) {
+            if (inventoryIds.contains(id) && this.currentItem != null && view.player == this@SimpleInventoryBuilder.player) {
+                if (inventory == this@SimpleInventoryBuilder.inventory) {
                     for (slot in slots.entries) {
                         if (slot.key == this.rawSlot){
                             this.isCancelled = true
@@ -88,15 +89,17 @@ class SimpleInventoryBuilder(
 
     @EventHandler
     private fun InventoryCloseEvent.listener3() {
-        for(closeHandler in closeHandlers)
-            closeHandler(this)
-        if(this.view.player == player && inventoryIds.contains(id))
+        if(view.player == this@SimpleInventoryBuilder.player && inventoryIds.contains(id)) {
+            for(closeHandler in closeHandlers)
+                closeHandler(this)
             inventoryIds.remove(id)
+            HandlerList.unregisterAll(this@SimpleInventoryBuilder)
+        }
     }
 
     @EventHandler
     private fun PlayerSwapHandItemsEvent.listener4() {
-        if (this.player.inventory == inventory) {
+        if (player.inventory == this@SimpleInventoryBuilder.inventory) {
             this.isCancelled = true
         }
     }


### PR DESCRIPTION
Two things in here:

1- If you have player A and player B, if player A and B opened a GUI, and player A closed its GUI, player B's GUI will be 100% unresponsive (since its inventoryID got removed, since the old if statement was basically ```if (event.player == event.player)```)

2- Our server had outstanding RAM usage coming from the InventoryBuilders (even after the inventories were closed!) When testing with the ```onClose``` method of the InventoryBuilder, I realized that it was always getting called when closing other GUIs, even non-related ones! I also saw that the listeners never got unregistered, which would make it impossible for the GC to clear the unused memory data. This was also fixed here. (With the ```HandlerList.unregisterAll``` call)