### PR TITLE
Ensure Paper Plugin Compatibility 

### DIFF
--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/InventoryGUI.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/InventoryGUI.kt
@@ -28,7 +28,7 @@ object InventoryGUI {
      * @throws IllegalArgumentException if not loaded by `io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader.class`
      * @throws IllegalStateException if the plugin is not found from the classloader
      */
-    var plugin: Plugin = JavaPlugin.getProvidingPlugin(InventoryGUI::class.java) ?: Downstream.pullPlugin()
+    var plugin: Plugin = Downstream.pullPlugin()
         private set
     }
 

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/InventoryGUI.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/InventoryGUI.kt
@@ -9,6 +9,7 @@ import net.projecttl.inventory.util.InventoryType
 import org.bukkit.entity.Player
 import org.bukkit.inventory.Inventory
 import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.java.JavaPlugin
 import java.util.*
 
 /**
@@ -21,27 +22,15 @@ object InventoryGUI {
     val inventoryIds = hashMapOf<UUID, InventoryBuilder>()
 
     /**
-     * The service plugin. Defaults to the plugin that loaded this library. You can modify this later if you want to
+     * The service plugin. Defaults to the plugin that loaded this library. You can modify this later if you want to.
      *
      * @throws InvalidPluginException if the current library isn't loaded by a plugin
+     * @throws IllegalArgumentException if not loaded by `io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader.class`
+     * @throws IllegalStateException if the plugin is not found from the classloader
      */
-    var plugin: Plugin = Downstream.pullPlugin()
+    var plugin: Plugin = JavaPlugin.getProvidingPlugin(InventoryGUI::class.java) ?: Downstream.pullPlugin()
         private set
-    /*
-    var plugin: JavaPlugin = javaClass.classLoader.run {
-        fun checkLoader(classLoader: ClassLoader): ClassLoader {
-            return if (classLoader is PluginClassLoader) {
-                this
-            } else {
-                if (classLoader.parent == null) throw InvalidPluginException("Should be loaded by a plugin")
-                checkLoader(classLoader.parent)
-            }
-        }
-
-        (checkLoader(this) as PluginClassLoader).plugin
     }
-     */
-}
 
 /**
  * Opens the default GUI for a player.

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/Downstream.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/Downstream.kt
@@ -1,8 +1,10 @@
 package net.projecttl.inventory.util
 
+import net.projecttl.inventory.InventoryGUI
 import org.bukkit.Bukkit
 import org.bukkit.plugin.InvalidPluginException
 import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.plugin.java.PluginClassLoader
 
 // from https://github.com/monun/heartbeat-coroutines/blob/master/heartbeat-coroutines/src/main/kotlin/io/github/monun/heartbeat/coroutines/Downstream.kt
@@ -19,6 +21,16 @@ internal object Downstream {
         get() = classLoaderFields.map { it.get(this) }.filterIsInstance<ClassLoader>()
 
     fun pullPlugin(): Plugin {
+        try{
+            val getProvidingPlugin = JavaPlugin::class.java.getDeclaredMethod("getProvidingPlugin", Class::class.java)
+
+            return getProvidingPlugin.invoke(null, InventoryGUI) as Plugin
+        }catch (_: NoSuchMethodException){}
+
+        return pullPluginBukkit()
+    }
+
+    private fun pullPluginBukkit(): Plugin {
         val classLoader = Downstream::class.java.classLoader
 
         return Bukkit.getPluginManager().plugins.find { plugin ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,8 @@ subprojects {
     version = rootProject.version
 
     repositories {
-        maven {
+        maven("https://repo.papermc.io/repository/maven-public/") {
             name = "papermc"
-            url = uri("https://repo.papermc.io/repository/maven-public/")
         }
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/") {
             name = "sonatype-oss-snapshots"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,10 @@ subprojects {
     version = rootProject.version
 
     repositories {
-        maven("https://papermc.io/repo/repository/maven-public/")
+        maven {
+            name = "papermc"
+            url = uri("https://repo.papermc.io/repository/maven-public/")
+        }
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/") {
             name = "sonatype-oss-snapshots"
         }
@@ -39,7 +42,7 @@ subprojects {
 
     dependencies {
         implementation(kotlin("stdlib"))
-        compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
         if (this@subprojects.name != "InventoryGUI-api") {
             dependencies {
                 implementation(project(":InventoryGUI-api"))


### PR DESCRIPTION
Changes:

- updated paper version from 1.21.3 => 1.21.4
- updated papers maven repo link to latest stable url
- replace Downstream#pullPlugin with JavaPlugin#getProvidingPlugin to prevent error when loading from Paper plugins

Original Error:
```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.ClassCastException: class io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader cannot be cast to class org.bukkit.plugin.java.PluginClassLoader (io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader and org.bukkit.plugin.java.PluginClassLoader are in unnamed module of loader java.net.URLClassLoader @2077d4de) [in thread "Server thread"]
        at MultiWorldGui-1.21-all.jar/net.projecttl.inventory.util.Downstream.pullPlugin(Downstream.kt:25) ~[MultiWorldGui-1.21-all.jar:?]
```