### PR TITLE
feat: added "duping prevention" to gui items

### DIFF
--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/SimpleInventoryBuilder.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/SimpleInventoryBuilder.kt
@@ -3,6 +3,7 @@ package net.projecttl.inventory.gui
 import net.kyori.adventure.text.Component
 import net.projecttl.inventory.InventoryGUI.inventoryIds
 import net.projecttl.inventory.InventoryGUI.plugin
+import net.projecttl.inventory.util.DupePrevention
 import net.projecttl.inventory.util.InventoryType
 import net.projecttl.inventory.util.Slot
 import net.projecttl.inventory.util.compareTo
@@ -38,6 +39,7 @@ class SimpleInventoryBuilder(
     }
 
     override fun slot(slot: Int, item: ItemStack, handler: InventoryClickEvent.() -> Unit) {
+        DupePrevention.setInventoryItem(item)
         slots[slot] = Slot(item, handler)
     }
 
@@ -59,6 +61,7 @@ class SimpleInventoryBuilder(
         for (slot in slots.entries) {
             inventory.setItem(slot.key, slot.value.stack)
         }
+        DupePrevention.tryRegisterEvents()
         player.openInventory(inventory)
         Bukkit.getServer().pluginManager.registerEvents(this, plugin)
         return inventory
@@ -92,6 +95,13 @@ class SimpleInventoryBuilder(
         if(view.player == this@SimpleInventoryBuilder.player && inventoryIds.contains(id)) {
             for(closeHandler in closeHandlers)
                 closeHandler(this)
+
+            for (item in player.inventory) {
+                if (DupePrevention.isInventoryItem(item)) {
+                    player.inventory.remove(item)
+                }
+            }
+
             inventoryIds.remove(id)
             HandlerList.unregisterAll(this@SimpleInventoryBuilder)
         }

--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/DupePrevention.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/DupePrevention.kt
@@ -1,0 +1,77 @@
+package net.projecttl.inventory.util
+
+import net.projecttl.inventory.InventoryGUI.plugin
+import org.bukkit.NamespacedKey
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityPickupItemEvent
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryPickupItemEvent
+import org.bukkit.event.player.PlayerDropItemEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
+
+
+val PDC_KEY = NamespacedKey(plugin, "is_inventory_item")
+
+class DupePrevention {
+    companion object : Listener {
+        private var registered = false
+
+        fun isInventoryItem(item: ItemStack?): Boolean {
+            return item?.itemMeta?.persistentDataContainer?.has(PDC_KEY, PersistentDataType.BOOLEAN) == true
+        }
+
+        fun setInventoryItem(item: ItemStack) {
+            item.editMeta { it.persistentDataContainer.set(PDC_KEY, PersistentDataType.BOOLEAN, true) }
+        }
+
+        fun tryRegisterEvents() {
+            if (!registered) {
+                plugin.server.pluginManager.registerEvents(this, plugin)
+                registered = true
+            }
+        }
+
+
+        // Prevents the item from being picked up by blocks (like hoppers)
+        @EventHandler
+        fun onItemPickup(event: InventoryPickupItemEvent) {
+            if (isInventoryItem(event.item.itemStack)) {
+                event.isCancelled = true
+                event.item.remove()
+            }
+        }
+
+        // Prevents the item from being picked up by players or other entities
+        @EventHandler
+        fun onEntityItemPickup(event: EntityPickupItemEvent) {
+            if (isInventoryItem(event.item.itemStack)) {
+                event.isCancelled = true
+                event.item.remove()
+            }
+        }
+
+        // Prevents the item from being dropped by a player
+        @EventHandler
+        fun onItemDropped(event: PlayerDropItemEvent) {
+            if (isInventoryItem(event.itemDrop.itemStack))
+                event.isCancelled = true
+        }
+
+        // If somehow the player still has the item, prevent them from clicking it
+        @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+        fun onItemClicked(event: InventoryClickEvent) {
+            if (isInventoryItem(event.currentItem)) { //if the player is trying to take the item
+                event.isCancelled = true
+                event.currentItem?.let { event.clickedInventory?.remove(it) }
+            }
+            if (isInventoryItem(event.cursor)) { //if the player is trying to "place" the item in an inventory
+                event.isCancelled = true
+                event.clickedInventory?.remove(event.cursor)
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Some players on my server were able to get items out of the GUI (and no, they were not ghost items). We are still insanely confused as to what could cause it, as we don't really have anything else that has to do with GUIs.

Therefore, I've added this "duping prevention" stuff that should ensure that getting items out of the guis would be incredibly hard to keep. Trying to drop, pickup or click a GUI item will be canceled, and when closing InventoryGUI's guis, it will scan the player's inventory to remove some gui items, if there were any.

This change could lead to _some_ performance impact, but this patch is quite critical for our server. Also, since this uses PersistentDataContainers, it means that the library would only work on MC version 1.14.1+