### PR TITLE
fix: potential exception when using paper plugins

### DIFF
--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/Downstream.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/util/Downstream.kt
@@ -22,9 +22,9 @@ internal object Downstream {
         val classLoader = Downstream::class.java.classLoader
 
         return Bukkit.getPluginManager().plugins.find { plugin ->
-            val pluginClassLoader = plugin.javaClass.classLoader as PluginClassLoader
+            val pluginClassLoader = plugin.javaClass.classLoader as? PluginClassLoader
 
-            pluginClassLoader === classLoader || pluginClassLoader.internalLoaders.any { it === classLoader }
+            pluginClassLoader === classLoader || pluginClassLoader?.internalLoaders?.any { it === classLoader } == true
         } ?: throw InvalidPluginException("The library must be loaded from PluginClassLoader")
     }
 }


### PR DESCRIPTION
When using paper plugins (as in, having ANY Paper plugin getting loaded), it's possible that the Paper class loader tries to get casted to Bukkit's which causes a cast exception. 

Note:
I currently fixed this by putting null checks, but this "pullPlugin" method might fail if InventoryGUI is loaded through a Paper plugin, which could be a potential issue.